### PR TITLE
Fix reference to field in asset()

### DIFF
--- a/src/TweedeGolf/MediaBundle/Entity/FileSerializer.php
+++ b/src/TweedeGolf/MediaBundle/Entity/FileSerializer.php
@@ -45,13 +45,13 @@ class FileSerializer
         $data = [
             'id'   => $file->getId(),
             'name' => $file->getFileName(),
-            'path' => $this->vich->asset($file, 'tgmedia_file'),
+            'path' => $this->vich->asset($file, 'file'),
             'size' => $this->formatSize($file->getFile()->getSize()),
             'mime' => $file->getFile()->getMimeType(),
         ];
 
         if ($file->isImage()) {
-            $fileName = $this->vich->asset($file, 'tgmedia_file');
+            $fileName = $this->vich->asset($file, 'file');
             $data['thumb'] = $this->imagine->getBrowserPath($fileName, 'tgmedia_thumbnail');
         } else {
             $data['type'] = $file->getExtension();


### PR DESCRIPTION
See https://github.com/dustin10/VichUploaderBundle/blob/master/UPGRADE.md
Unfortunately, VichUploaderBundle mande a breaking change in v0.13.0, so you cannot refer to mapping name anymore, but you MUST refer to field name.
This also means that you should upgrade your require for VichUploaderBundle to ~0.13
