### PR TITLE
add missing setters

### DIFF
--- a/src/TweedeGolf/MediaBundle/Entity/File.php
+++ b/src/TweedeGolf/MediaBundle/Entity/File.php
@@ -206,4 +206,28 @@ class File
             'image/png',
         ];
     }
+
+    /**
+     * @param string $type
+     *
+     * @return File
+     */
+    public function setMimeType($type)
+    {
+        $this->mimeType = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param int $size
+     *
+     * @return File
+     */
+    public function setFileSize($size)
+    {
+        $this->fileSize = $size;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
These setters are needed if you want to create arbitrary File objects (e.g. when populating database with fixtures).
