### PR TITLE
make File entity configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,53 @@ Then run `composer update tweedegolf/media-bundle`
 For installation instructions of the [media browser, see the repository](https://github.com/tweedegolf/media-browser).
 
 ### Basic configuration
+
 Define mappings in your configuration file `app/config/config.yml`:
 
 You can configure the maximum number of items displayed per page.
 
+You **must** configure the name of your File entity.
+
 ```yaml
 tweede_golf_media:
-    max_per_page: 24  # default is 18
+    max_per_page: 24  # this is optional (default is 18)
+    file_entity: 'AppBundle:File'  # this is required
+```
+
+This is an example of File entity you can define:
+
+```php
+<?php
+
+namespace AppBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use TweedeGolf\MediaBundle\Model\AbstractFile
+
+/**
+ * @ORM\Entity
+ * @ORM\Table
+ * @ORM\Entity(repositoryClass="TweedeGolf\MediaBundle\Entity\FileRepository")
+ */
+class File extends AbstractFile
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+
 ```
 
 Also, the MediaBundle depends on some configurations in other bundles. There needs to be a VichUploader mapping defined with the name `tgmedia_files`. Furthermore, there has to be a LiipImagine filter with the name `tgmedia_thumbnail`.

--- a/src/TweedeGolf/MediaBundle/Controller/ApiController.php
+++ b/src/TweedeGolf/MediaBundle/Controller/ApiController.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use TweedeGolf\MediaBundle\Entity\File;
+use TweedeGolf\MediaBundle\Model\AbstractFile;
 
 /**
  * Class MediaController
@@ -39,8 +39,7 @@ class ApiController extends Controller
         $page = $request->query->get('page', 1);
         $max = $this->container->getParameter('tweede_golf_media.max_per_page');
 
-        $repo = $this->getDoctrine()->getRepository('TweedeGolfMediaBundle:File');
-        $paginator = $repo->findSubset($filter, $order, $page, $max);
+        $paginator = $this->get('tweedegolf.repository.file')->findSubset($filter, $order, $page, $max);
         $data = $this->get('tweedegolf.media.file_serializer')->serializeAll($paginator);
 
         return new JsonResponse([
@@ -64,7 +63,7 @@ class ApiController extends Controller
         if ($id !== null) {
 
             $em = $this->getDoctrine()->getManager();
-            $entity = $em->getRepository('TweedeGolfMediaBundle:File')->find($id);
+            $entity = $this->get('tweedegolf.repository.file')->find($id);
 
             if (!$entity) {
                 return new JsonResponse([
@@ -129,10 +128,10 @@ class ApiController extends Controller
      * Create the upload form
      * Only used for validation
      *
-     * @param File $entity
+     * @param AbstractFile $entity
      * @return Form
      */
-    protected function createCreateForm(File $entity)
+    protected function createCreateForm(AbstractFile $entity)
     {
         $builder = $this->get('form.factory')->createNamedBuilder('', 'form', $entity, [
             'csrf_protection' => false,

--- a/src/TweedeGolf/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/TweedeGolf/MediaBundle/DependencyInjection/Configuration.php
@@ -24,6 +24,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('max_per_page')
                     ->defaultValue(18)
                 ->end()
+                ->scalarNode('file_entity')
+                    ->isRequired()
+                ->end()
             ->end()
         ;
 

--- a/src/TweedeGolf/MediaBundle/DependencyInjection/TweedeGolfMediaExtension.php
+++ b/src/TweedeGolf/MediaBundle/DependencyInjection/TweedeGolfMediaExtension.php
@@ -18,6 +18,7 @@ class TweedeGolfMediaExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('tweede_golf_media.max_per_page', $config['max_per_page']);
+        $container->setParameter('tweede_golf_media.file_entity', $config['file_entity']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/TweedeGolf/MediaBundle/Model/AbstractFile.php
+++ b/src/TweedeGolf/MediaBundle/Model/AbstractFile.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace TweedeGolf\MediaBundle\Entity;
+namespace TweedeGolf\MediaBundle\Model;
 
 use Doctrine\ORM\Mapping as ORM;
-use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File as UploadedFile;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
@@ -12,23 +11,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * Attachment
  *
- * @ORM\Entity
- * @ORM\Table()
+ * @ORM\MappedSuperclass
  * @Vich\Uploadable
- * @ORM\Entity(repositoryClass="TweedeGolf\MediaBundle\Entity\FileRepository")
  */
-class File
+abstract class AbstractFile
 {
     use TimestampableEntity;
-
-    /**
-     * @var integer
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
 
     /**
      * @Assert\File(maxSize="20M", mimeTypes={
@@ -55,25 +43,25 @@ class File
      *
      * @var UploadedFile $file
      */
-    private $file;
+    protected $file;
 
     /**
      * @var string $fileName
      * @ORM\Column(type="string", length=255, nullable=false)
      */
-    private $fileName;
+    protected $fileName;
 
     /**
      * @var string $fileSize
      * @ORM\Column(type="integer", nullable=false)
      */
-    private $fileSize;
+    protected $fileSize;
 
     /**
      * @var string $mimeType
      * @ORM\Column(type="string", length=255, nullable=false)
      */
-    private $mimeType;
+    protected $mimeType;
 
     /**
      * Return the string representation of this entity
@@ -82,16 +70,6 @@ class File
     public function __toString()
     {
         return $this->fileName;
-    }
-
-    /**
-     * Get id
-     *
-     * @return integer
-     */
-    public function getId()
-    {
-        return $this->id;
     }
 
     /**

--- a/src/TweedeGolf/MediaBundle/Resources/config/services.yml
+++ b/src/TweedeGolf/MediaBundle/Resources/config/services.yml
@@ -5,3 +5,7 @@ services:
         arguments:
             - @vich_uploader.templating.helper.uploader_helper
             - @liip_imagine.cache.manager
+    tweedegolf.repository.file:
+        class: TweedeGolf\MediaBundle\Entity\FileRepository
+        factory: ['@doctrine', getRepository]
+        arguments: ['%tweede_golf_media.file_entity%']

--- a/src/TweedeGolf/MediaBundle/TweedeGolfMediaBundle.php
+++ b/src/TweedeGolf/MediaBundle/TweedeGolfMediaBundle.php
@@ -7,5 +7,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class TweedeGolfMediaBundle extends Bundle
 {
-
 }


### PR DESCRIPTION
This is an important change, since the old behaviour about File entity is really limited.
Whit this enhancement, the user of the bundle is able to define their own entity, so they can add new properties, new relations, etc. Think about the requirement of adding a tag to a File (that was an actual requirement of mine).

The bad news is that change is introducing a **BC break**: the user now needs to define an entity (a really simple one, as you can see in the added documentation), since the old Entity is now an abstract mapped superclass.
My suggestion is, after merging this, to add a new tag with a change of version (e.g. `v0.2.0`). In this case, you'll also need to adapt the current `branch-alias` value.
